### PR TITLE
fix: preserve string-typed params as raw strings instead of parsing as JSON

### DIFF
--- a/cmd/cmd_action.go
+++ b/cmd/cmd_action.go
@@ -87,6 +87,7 @@ func doAction(ctx *Context, serviceName, action string) (err error) {
 	method := "GET"
 	contentType := ""
 	apiInfo := rootSupport.GetApiInfo(serviceName, action)
+	apiMeta := rootSupport.GetApiMeta(serviceName, action)
 
 	if apiInfo != nil && apiInfo.Method != "" {
 		method = apiInfo.Method
@@ -100,7 +101,14 @@ func doAction(ctx *Context, serviceName, action string) (err error) {
 	for _, f := range ctx.dynamicFlags.flags {
 		// rebuild input
 		if f.Name != "body" {
-			if a, success := util.ParseToJsonArrayOrObject(strings.TrimSpace(f.value)); success {
+			// Skip JSON parsing for parameters whose declared type is "string".
+			// Without this, a value like '{"Statement":[...]}' is deserialized
+			// into a Go map and then flattened into query params, which breaks
+			// APIs that expect a raw JSON string (e.g. IAM CreatePolicy's
+			// PolicyDocument parameter).
+			if isStringParam(apiMeta, f.Name) {
+				input[f.Name] = f.value
+			} else if a, success := util.ParseToJsonArrayOrObject(strings.TrimSpace(f.value)); success {
 				input[f.Name] = a
 			} else {
 				input[f.Name] = f.value
@@ -171,6 +179,18 @@ func doAction(ctx *Context, serviceName, action string) (err error) {
 		util.ShowJson(*out, true)
 	}
 	return
+}
+
+// isStringParam reports whether the named parameter is declared as type
+// "string" in the API metadata. When true, the caller must NOT attempt to
+// parse the value as JSON, because the API expects a literal string — even
+// if that string happens to contain valid JSON (e.g. PolicyDocument).
+func isStringParam(apiMeta *ApiMeta, name string) bool {
+	if apiMeta == nil || apiMeta.Request == nil || apiMeta.Request.MetaTypes == nil {
+		return false
+	}
+	mt, ok := apiMeta.Request.MetaTypes[name]
+	return ok && mt.TypeName == "string"
 }
 
 func actionUsageTemplate(params []string) string {

--- a/cmd/cmd_action_test.go
+++ b/cmd/cmd_action_test.go
@@ -1,0 +1,65 @@
+package cmd
+
+import "testing"
+
+func TestIsStringParam(t *testing.T) {
+	tests := []struct {
+		name     string
+		apiMeta  *ApiMeta
+		param    string
+		expected bool
+	}{
+		{
+			name:     "nil apiMeta",
+			apiMeta:  nil,
+			param:    "PolicyDocument",
+			expected: false,
+		},
+		{
+			name: "string type param",
+			apiMeta: &ApiMeta{
+				Request: &Meta{
+					MetaTypes: map[string]*MetaType{
+						"PolicyDocument": {TypeName: "string"},
+						"PolicyName":     {TypeName: "string"},
+					},
+				},
+			},
+			param:    "PolicyDocument",
+			expected: true,
+		},
+		{
+			name: "non-string type param",
+			apiMeta: &ApiMeta{
+				Request: &Meta{
+					MetaTypes: map[string]*MetaType{
+						"Filters": {TypeName: "object"},
+					},
+				},
+			},
+			param:    "Filters",
+			expected: false,
+		},
+		{
+			name: "unknown param",
+			apiMeta: &ApiMeta{
+				Request: &Meta{
+					MetaTypes: map[string]*MetaType{
+						"PolicyName": {TypeName: "string"},
+					},
+				},
+			},
+			param:    "Unknown",
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isStringParam(tt.apiMeta, tt.param)
+			if got != tt.expected {
+				t.Errorf("isStringParam(%v, %q) = %v, want %v", tt.apiMeta, tt.param, got, tt.expected)
+			}
+		})
+	}
+}

--- a/cmd/root_support.go
+++ b/cmd/root_support.go
@@ -117,6 +117,13 @@ func (r *RootSupport) GetVersion(svc string) string {
 	return r.Versions[svc]
 }
 
+func (r *RootSupport) GetApiMeta(svc string, action string) *ApiMeta {
+	if metas, ok := r.SupportTypes[svc]; ok {
+		return metas[action]
+	}
+	return nil
+}
+
 func (r *RootSupport) GetApiInfo(svc string, action string) *ApiInfo {
 	for k, v := range r.SupportAction {
 		if k == svc {


### PR DESCRIPTION
## Problem

When a CLI parameter value looks like valid JSON (starts with `{` or `[`), `ParseToJsonArrayOrObject` deserializes it into a Go map/slice. The SDK's `volcenginequery.BuildHandler` then serializes the map as flattened query params:

```
PolicyDocument.Statement.0.Effect=Allow&PolicyDocument.Statement.0.Action.0=volcSMS:SendSms&...
```

This breaks APIs that expect the parameter to be a **raw JSON string**, such as IAM `CreatePolicy`'s `PolicyDocument`:

```bash
# Always fails with "InvalidPolicy.Structure: Document is not a valid JSON string."
ve iam CreatePolicy --PolicyName MyPolicy --PolicyDocument '{"Statement":[{"Effect":"Allow","Action":["tos:*"],"Resource":["*"]}]}'
```

## Root Cause

In `cmd_action.go`, the parameter parsing loop unconditionally attempts JSON deserialization on all non-`body` flag values (line 103). There is no check for whether the API actually expects a structured object or a plain string.

## Fix

Use the existing API metadata (`metatype`) to look up each parameter's declared type. If the type is `"string"`, skip `ParseToJsonArrayOrObject` and pass the value as-is. This is a minimal, targeted fix:

- Added `GetApiMeta()` to `RootSupport` to expose per-action type metadata
- Added `isStringParam()` helper that checks if a parameter is declared as `"string"` type
- Modified the `doAction` parameter loop to skip JSON parsing for string-typed params
- Added unit tests for `isStringParam`

Parameters without type metadata (i.e., `ApiMeta` is nil) retain the existing behavior — JSON parsing is still attempted as a best-effort heuristic.

## Test Plan

- [x] `go build ./...` passes
- [x] Unit tests for `isStringParam` pass
- [ ] Manual test: `ve iam CreatePolicy --PolicyDocument '{"Statement":[...]}'` should succeed